### PR TITLE
Updated csv download to use blob

### DIFF
--- a/src/client/components/App.jsx
+++ b/src/client/components/App.jsx
@@ -143,12 +143,14 @@ function App() {
       ]);
     });
     const csvContent = csv.map((e) => e.join(",")).join("\n");
-    const encodedUri = encodeURIComponent(csvContent);
-    const link = document.createElement("a");
-    link.setAttribute("href", `data:text/csv;charset=utf-8,${encodedUri}`);
-    link.setAttribute("download", `${playlistName.replaceAll(" ", "_")}.csv`);
-    document.body.appendChild(link);
-    link.click();
+    const blob = new Blob([csvContent], { type: 'text/csv' });
+
+    const downloadLink = document.createElement('a');
+    downloadLink.href = URL.createObjectURL(blob);
+    downloadLink.download = `${playlistName.replaceAll(" ", "_")}.csv`;
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
   };
 
   const login = () => {

--- a/src/client/components/App.jsx
+++ b/src/client/components/App.jsx
@@ -151,6 +151,12 @@ function App() {
     document.body.appendChild(downloadLink);
     downloadLink.click();
     document.body.removeChild(downloadLink);
+
+    setTimeout(() => {
+      // Revoke the Blob URL after a short timeout
+      URL.revokeObjectURL(downloadLink.href);
+      document.body.removeChild(downloadLink);
+    }, 0); // Schedule the revoke after file has downloaded
   };
 
   const login = () => {


### PR DESCRIPTION
Previous code used EncodeURIComponent() which encodes your csv data and then appends it to the dummy link, which can potentially be a problem if the link becomes too long (aka too much data in csv).

In the new code, encodeURIComponent is no longer used for the CSV data. The Blob handles the binary representation of the CSV content, and createObjectURL generates a URL for the blob. The href attribute is set directly to this URL without the need for additional encoding.

